### PR TITLE
Initial translation of strings into Tetum

### DIFF
--- a/lib/lang/tet.js
+++ b/lib/lang/tet.js
@@ -1,0 +1,145 @@
+function join_with_shared_prefix(a, b, joiner) {
+  var i = 0;
+
+  while(i !== a.length &&
+        i !== b.length &&
+        a.charCodeAt(i) === b.charCodeAt(i))
+    ++i;
+
+  return a.slice(0, i) + a.slice(i) + joiner + b.slice(i);
+}
+
+function strip_prefix(period) {
+  return period.slice(0, 9) === "iha kalan" ? period.slice(4) :
+         period.slice(0, 7) ===   "iha " ? period.slice(7) :
+                                              period;
+}
+
+module.exports = require("../template")({
+  "clear": "pas",
+  "no-precipitation": "udan la iha",
+  "mixed-precipitation": "udan - maran kahur",
+  "possible-very-light-precipitation": "karik udan uituan deit",
+  "very-light-precipitation": "udan uituan",
+  "possible-light-precipitation": "karik udan uituan",
+  "light-precipitation": "udan uituan",
+  "medium-precipitation": "udan",
+  "heavy-precipitation": "udan bo'ot",
+  "possible-very-light-rain": "karik udan uituan deit",
+  "very-light-rain": "udan uituan deit",
+  "possible-light-rain": "karik udan uituan",
+  "light-rain": "udan uituan",
+  "medium-rain": "udan",
+  "heavy-rain": "udan bo'ot",
+  "possible-very-light-sleet": "karik udan - salju kahur uituan deit",
+  "very-light-sleet": "udan - salju kahur uituan deit",
+  "possible-light-sleet": "karik udan - salju kahur uituan",
+  "light-sleet": "udan - salju kahur uituan",
+  "medium-sleet": "udan - salju kahur",
+  "heavy-sleet": "udan - salju kahur bo'ot",
+  "possible-very-light-snow": "karik salju uituan deit",
+  "very-light-snow": "salju uituan deit",
+  "possible-light-snow": "karik salju uituan",
+  "light-snow": "salju uituan",
+  "medium-snow": "salju",
+  "heavy-snow": "salju bo'ot",
+  "light-wind": "anin ki'ik",
+  "medium-wind": "anin",
+  "heavy-wind": "anin bo'ot",
+  "low-humidity": "maran",
+  "high-humidity": "bokon",
+  "fog": "abu-abu taka rai",
+  "light-clouds": "abu-abu uituan",
+  "medium-clouds": "abu-abu",
+  "heavy-clouds": "abu-abu taka loron",
+  "today-morning": "ohin dader",
+  "later-today-morning": "orsida ohin dader",
+  "today-afternoon": "ohin lokraik",
+  "later-today-afternoon": "orsida lokraik",
+  "today-evening": "ohin kalan",
+  "later-today-evening": "orsida kalan",
+  "today-night": "ohin kalan bo'ot",
+  "later-today-night": "orsida kalan bo'ot",
+  "tomorrow-morning": "aban dader",
+  "tomorrow-afternoon": "aban lokraik",
+  "tomorrow-evening": "aban kalan",
+  "tomorrow-night": "aban kalan bo'ot",
+  "morning": "iha dader",
+  "afternoon": "lokraik",
+  "evening": "iha kalan",
+  "night": "iha kalan bo'ot",
+  "today": "ohin",
+  "tomorrow": "aban",
+  "sunday": "iha Domingu",
+  "monday": "iha Segunda",
+  "tuesday": "iha Tersa",
+  "wednesday": "iha Kuarta",
+  "thursday": "iha Kinta",
+  "friday": "iha Sexta",
+  "saturday": "iha Sabadu",
+  "minutes": "$1 min.",
+  "fahrenheit": "$1\u00B0F",
+  "celsius": "$1\u00B0C",
+  "inches": "$1 in.",
+  "centimeters": "$1 cm.",
+  "less-than": "$1 mai kraik",
+  "and": function(a, b) {
+    return join_with_shared_prefix(
+      a,
+      b,
+      a.indexOf(",") !== -1 ? ", ho " : " ho "
+    );
+  },
+  "through": function(a, b) {
+    return join_with_shared_prefix(a, b, " to ");
+  },
+  "with": "$1, ho $2",
+  "range": "$1\u2013$2",
+  "parenthetical": "$1 ($2)",
+  "for-hour": "$1 ba oras ida",
+  "starting-in": "$1 hahu iha $2",
+  "stopping-in": "$1 para iha $2",
+  "starting-then-stopping-later": "$1 hahu iha $2, hein $3 para",
+  "stopping-then-starting-later": "$1 para iha $2, hein $3 hahu fali",
+  "for-day": "$1 loron tomak",
+  "starting": "$1 hahu $2",
+  "until": function(condition, period) {
+    return condition + " to " + strip_prefix(period);
+  },
+  "until-starting-again": function(condition, a, b) {
+    return condition + " to " + strip_prefix(a) + ", hahu fali " + b;
+  },
+  "starting-continuing-until": function(condition, a, b) {
+    return condition + " hahu " + a + ", kontinua to " +
+           strip_prefix(b);
+  },
+  "during": "$1 $2",
+  "for-week": "$1 durante semana ida",
+  "over-weekend": "$1 durante Sabadu - Domingu",
+  "temperatures-peaking": "temperatur la sai liu $1 $2",
+  "temperatures-rising": "temperatur sai to $1 $2",
+  "temperatures-valleying": "temperatur la tun liu $1 $2",
+  "temperatures-falling": "temperatur tun to $1 $2",
+  /* Capitalize the first letter of every word, except if that word is
+   * "and". (This is a very crude bastardization of proper English titling
+   * rules, but it is adequate for the purposes of this module.) */
+  "title": function(str) {
+    return str.replace(
+      /\b(?:a(?!nd\b)|[^\Wa])/g,
+      function(letter) {
+        return letter.toUpperCase();
+      }
+    );
+  },
+  /* Capitalize the first word of the sentence and end with a period. */
+  "sentence": function(str) {
+    /* Capitalize. */
+    str = str.charAt(0).toUpperCase() + str.slice(1);
+
+    /* Add a period if there isn't already one. */
+    if(str.charAt(str.length - 1) !== ".")
+      str += ".";
+
+    return str;
+  }
+});

--- a/test-cases/tet.json
+++ b/test-cases/tet.json
@@ -1,0 +1,237 @@
+{
+  "Pas":
+    ["title", "clear"],
+
+  "Karik Udan Uituan Deit":
+    ["title", "possible-very-light-precipitation"],
+
+  "Udan Uituan Deit":
+    ["title", "very-light-precipitation"],
+
+  "Karik Udan Uituan":
+    ["title", "possible-light-precipitation"],
+
+  "Udan Uituan":
+    ["title", "light-precipitation"],
+
+  "Udan":
+    ["title", "medium-precipitation"],
+
+  "Udan Bo'ot":
+    ["title", "heavy-precipitation"],
+
+  "Karik Udan Uituan Deit":
+    ["title", "possible-very-light-rain"],
+
+  "Udan Uituan Deit":
+    ["title", "very-light-rain"],
+
+  "Karik Udan Uituan":
+    ["title", "possible-light-rain"],
+
+  "Udan Uituan":
+    ["title", "light-rain"],
+
+  "Udan":
+    ["title", "medium-rain"],
+
+  "Udan Bo'ot":
+    ["title", "heavy-rain"],
+
+  "Karik Udan - Salju Kahur Uituan Deit":
+    ["title", "possible-very-light-sleet"],
+
+  "Udan - Salju Kahur Uituan Deit":
+    ["title", "very-light-sleet"],
+
+  "Karik Udan - Salju Kahur Uituan":
+    ["title", "possible-light-sleet"],
+
+  "Udan - Salju Kahur Uituan":
+    ["title", "light-sleet"],
+
+  "Udan - Salju Kahur":
+    ["title", "medium-sleet"],
+
+  "Udan - Salju Kahur Bo'ot":
+    ["title", "heavy-sleet"],
+
+  "Karik Salju Uituan Deit":
+    ["title", "possible-very-light-snow"],
+
+  "Salju Uituan Deit":
+    ["title", "very-light-snow"],
+
+  "Karik Salju Uituan":
+    ["title", "possible-light-snow"],
+
+  "Salju Uituan":
+    ["title", "light-snow"],
+
+  "Salju":
+    ["title", "medium-snow"],
+
+  "Salju Bo'ot":
+    ["title", "heavy-snow"],
+
+  "Anin":
+    ["title", "medium-wind"],
+
+  "Anin Bo'ot":
+    ["title", "heavy-wind"],
+
+  "Abu-Abu Taka Rai":
+    ["title", "fog"],
+
+  "Abu-Abu":
+    ["title", "medium-clouds"],
+
+  "Abu-Abu Taka Loron":
+    ["title", "heavy-clouds"],
+
+  "Maran Ho Anin Ki'ik":
+    ["title", ["and", "low-humidity", "light-wind"]],
+
+  "Bokon Ho Abu-Abu Uituan":
+    ["title",
+      ["and", "high-humidity", "light-clouds"]],
+
+
+  "Pas ba oras ida.":
+    ["sentence", ["for-hour", "clear"]],
+
+  "Salju uituan deit hahu iha 35 min.":
+    ["sentence", ["starting-in", "very-light-snow", ["minutes", 35]]],
+
+  "Udan uituan para iha 15 min.":
+    ["sentence", ["stopping-in", "light-rain", ["minutes", 15]]],
+
+  "Udan - salju kahur bo'ot hahu iha 20 min., hein 30 min. para.":
+    ["sentence",
+      ["starting-then-stopping-later",
+        "heavy-sleet",
+        ["minutes", 20],
+        ["minutes", 30]]],
+
+  "Udan para iha 25 min., hein 8 min. hahu fali.":
+    ["sentence",
+      ["stopping-then-starting-later",
+        "medium-rain",
+        ["minutes", 25],
+        ["minutes", 8]]],
+
+
+  "Abu-abu loron tomak.":
+    ["sentence", ["for-day", "medium-clouds"]],
+
+  "Udan - salju kahur uituan deit hahu iha dader.":
+    ["sentence", ["starting", "very-light-sleet", "morning"]],
+
+  "Anin to ohin kalan bo'ot.":
+    ["sentence", ["until", "medium-wind", "today-night"]],
+
+  "Udan bo'ot to lokraik.":
+    ["sentence", ["until", "heavy-precipitation", "afternoon"]],
+
+  "Anin ki'ik lokraik.":
+    ["sentence", ["during", "light-wind", "afternoon"]],
+
+  "Salju orsida kalan ho aban dader.":
+    ["sentence", ["during",
+      "medium-snow",
+      ["and", "later-today-evening", "tomorrow-morning"]]],
+
+  "Udan bo'ot to orsida ohin dader, hahu fali ohin kalan.":
+    ["sentence", ["until-starting-again",
+      "heavy-rain",
+      "later-today-morning",
+      "today-evening"]],
+
+  "Abu-abu taka loron hahu iha kalan, kontinua to kalan bo'ot.":
+    ["sentence", ["starting-continuing-until",
+      "heavy-clouds",
+      "evening",
+      "night"]],
+
+  "Udan - salju kahur uituan orsida lokraik ho abu-abu taka rai aban dader.":
+    ["sentence", ["and",
+      ["during", "light-sleet", "later-today-afternoon"],
+      ["during", "fog", "tomorrow-morning"]]],
+
+  "Anin bo'ot hahu ohin dader, kontinua to ohin lokraik, ho udan - salju kahur aban dader.":
+    ["sentence", ["and",
+      ["starting-continuing-until",
+        "heavy-wind",
+        "today-morning",
+        "today-afternoon"],
+      ["during", "medium-sleet", "tomorrow-morning"]]],
+
+  "Abu-abu taka loron hahu orsida kalan bo'ot ho salju bo'ot aban lokraik.":
+    ["sentence", ["and",
+      ["starting", "heavy-clouds", "later-today-night"],
+      ["during", "heavy-snow", "tomorrow-afternoon"]]],
+
+  "Maran ohin kalan bo'ot ho udan uituan hahu aban kalan, kontinua to aban kalan bo'ot.":
+    ["sentence", ["and",
+      ["during", "low-humidity", "today-night"],
+      ["starting-continuing-until",
+        "light-precipitation",
+        "tomorrow-evening",
+        "tomorrow-night"]]],
+
+  "Salju (5 in.) iha kalan bo'ot.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["inches", 5]],
+      "night"]],
+
+  "Salju uituan (2 cm.) orsida ohin dader.":
+    ["sentence", ["during",
+      ["parenthetical", "light-snow", ["centimeters", 2]],
+      "later-today-morning"]],
+
+  "Salju bo'ot (8\u201312 in.) loron tomak.":
+    ["sentence", ["for-day",
+      ["parenthetical", "heavy-snow", ["inches", ["range", 8, 12]]]]],
+
+  "Salju (1 cm. mai kraik) lokraik.":
+    ["sentence", ["during",
+      ["parenthetical", "medium-snow", ["centimeters", ["less-than", 1]]],
+      "afternoon"]],
+
+  "Udan la iha durante semana ida, ho temperatur la sai liu 85\u00B0F aban.":
+    ["sentence", ["with",
+      ["for-week", "no-precipitation"],
+      ["temperatures-peaking",
+        ["fahrenheit", 85],
+        "tomorrow"]]],
+
+  "Udan - maran kahur durante Sabadu - Domingu, ho temperatur sai to 32\u00B0C iha Kinta.":
+    ["sentence", ["with",
+      ["over-weekend", "mixed-precipitation"],
+      ["temperatures-rising",
+        ["celsius", 32],
+        "thursday"]]],
+
+  "Udan uituan deit ohin, ho temperatur la tun liu 15\u00B0F iha Sexta.":
+    ["sentence", ["with",
+      ["during", "very-light-rain", "today"],
+      ["temperatures-valleying",
+        ["fahrenheit", 15],
+        "friday"]]],
+
+  "Salju uituan iha Segunda ho Tersa, ho temperatur tun to 0\u00B0C iha Domingu.":
+    ["sentence", ["with",
+      ["during", "light-snow", ["and", "monday", "tuesday"]],
+      ["temperatures-falling",
+        ["celsius", 0],
+        "sunday"]]],
+
+  "Udan iha Kuarta to Sabadu, ho temperatur la sai liu 100\u00B0F iha Segunda.":
+    ["sentence", ["with",
+      ["during",
+        "medium-precipitation",
+        ["through", "wednesday", "saturday"]],
+      ["temperatures-peaking",
+        ["fahrenheit", 100],
+        "monday"]]]
+}


### PR DESCRIPTION
Initial translation of strings into Tetum, the national language of Timor-Leste.

The translations fail a few tests where the test expects the character following a `'` to be capitalized, which is incorrect.
