### PR TITLE
Spanish translations

### DIFF
--- a/lib/lang/es.js
+++ b/lib/lang/es.js
@@ -27,14 +27,14 @@ function strip_prefix(period) {
 
 module.exports = require("../template")({
   "clear": "claro",
-  "no-precipitation": "no precipitacion",
-  "mixed-precipitation": "precipitacion mixta",
+  "no-precipitation": "no precipitación",
+  "mixed-precipitation": "precipitación mixta",
   "possible-very-light-precipitation": "posible lluvias ligeras",
   "very-light-precipitation": "lluvias ligeras",
   "possible-light-precipitation": "posible lluvias ligeras",
-  "light-precipitation": "precipitacion ligera",
-  "medium-precipitation": "precipitacion",
-  "heavy-precipitation": "fuerte precipitacion",
+  "light-precipitation": "precipitación ligera",
+  "medium-precipitation": "precipitación",
+  "heavy-precipitation": "fuerte precipitación",
   "possible-very-light-rain": "posible llovizna",
   "very-light-rain": "llovizna",
   "possible-light-rain": "posible lluvia ligera",
@@ -57,7 +57,7 @@ module.exports = require("../template")({
   "medium-wind": "ventoso",
   "heavy-wind": "peligrosamente ventoso",
   "low-humidity": "seco",
-  "high-humidity": "humedo",
+  "high-humidity": "húmedo",
   "fog": "nublado",
   "light-clouds": "parcialmente nublado",
   "medium-clouds": "mayormente nublado",
@@ -134,12 +134,11 @@ module.exports = require("../template")({
    * "and". (This is a very crude bastardization of proper English titling
    * rules, but it is adequate for the purposes of this module.) */
   "title": function(str) {
-    return str.replace(
-      /\b(?:a(?!nd\b)|[^\Wy])/g,
-      function(letter) {
-        return letter.toUpperCase();
-      }
-    );
+    return str.replace(/\S+/g, function(word) {
+      return word === "y" ?
+        word :
+        word.charAt(0).toUpperCase() + word.slice(1);
+    });
   },
   /* Capitalize the first word of the sentence and end with a period. */
   "sentence": function(str) {

--- a/test_cases/es.json
+++ b/test_cases/es.json
@@ -5,19 +5,19 @@
   "Posible Lluvias Ligeras":
     ["title", "possible-very-light-precipitation"],
 
-  "Precipitacion Ligera":
+  "Precipitación Ligera":
     ["title", "very-light-precipitation"],
 
   "Posible Lluvias Ligeras":
     ["title", "possible-light-precipitation"],
 
-  "Precipitacion Ligera":
+  "Precipitación Ligera":
     ["title", "light-precipitation"],
 
-  "Precipitacion":
+  "Precipitación":
     ["title", "medium-precipitation"],
 
-  "Fuerte Precipitacion":
+  "Fuerte Precipitación":
     ["title", "heavy-precipitation"],
 
   "Posible Llovizna":
@@ -95,7 +95,7 @@
   "Llovizna y Peligrosamente Ventoso":
     ["title", ["and", "very-light-rain", "heavy-wind"]],
 
-  "Humedo y Parcialmente Nublado":
+  "Húmedo y Parcialmente Nublado":
     ["title", ["and", "high-humidity", "light-clouds"]],
 
   "Claro por la hora.":
@@ -130,7 +130,7 @@
   "Ventoso hasta esta noche.":
     ["sentence", ["until", "medium-wind", "today-night"]],
 
-  "Fuerte precipitacion hasta en la tarde.":
+  "Fuerte precipitación hasta en la tarde.":
     ["sentence", ["until", "heavy-precipitation", "afternoon"]],
 
   "Pocos vientos en la tarde.":
@@ -171,7 +171,7 @@
       ["starting", "heavy-clouds", "later-today-night"],
       ["during", "heavy-snow", "tomorrow-afternoon"]]],
 
-  "Seco esta noche y precipitacion ligera comenzando mañana en la noche, continuando hasta mañana en la noche.":
+  "Seco esta noche y precipitación ligera comenzando mañana en la noche, continuando hasta mañana en la noche.":
     ["sentence", ["and",
       ["during", "low-humidity", "today-night"],
       ["starting-continuing-until",
@@ -199,14 +199,14 @@
       "afternoon"]],
 
 
-  "No precipitacion durante la semana, con temperaturas alcanzando un máximo de 85\u00B0F mañana.":
+  "No precipitación durante la semana, con temperaturas alcanzando un máximo de 85\u00B0F mañana.":
     ["sentence", ["with",
       ["for-week", "no-precipitation"],
       ["temperatures-peaking",
         ["fahrenheit", 85],
         "tomorrow"]]],
 
-  "Precipitacion mixta sobre el fin de semana, con temperaturas llegando a 32\u00B0C el Jueves.":
+  "Precipitación mixta sobre el fin de semana, con temperaturas llegando a 32\u00B0C el Jueves.":
     ["sentence", ["with",
       ["over-weekend", "mixed-precipitation"],
       ["temperatures-rising",
@@ -227,7 +227,7 @@
         ["celsius", 0],
         "sunday"]]],
 
-  "Precipitacion hoy hasta el Sabado, con temperaturas alcanzando un máximo de 100\u00B0F el Lunes.":
+  "Precipitación hoy hasta el Sabado, con temperaturas alcanzando un máximo de 100\u00B0F el Lunes.":
     ["sentence", ["with",
       ["during",
         "medium-precipitation",


### PR DESCRIPTION
Hola! :grin: 
I worked through the spanish translations and everything looks green. The only bummer I ran into was the "and" regex being thrown off by accented characters. e.g. the ú in Húmedo (for humid) and ó in Precipitación. 

The regex matches on the following character and capitalizes it. I removed any instances of the ´accent for now.
